### PR TITLE
iOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ I will no longer maintain this plugin. If you want to make changes, feel free to
 This plugin provides the functionality from the SumUp API for the
 SumUp payment terminals.
 
-At the moment the plugin is only available for **Android**.
-**iOS** support will be added soon.
-
 If something is wrong with the plugin feel free to open an issue or make a pull request.
 
 ## Installation
@@ -163,6 +160,20 @@ Checks whether the user is logged in or not and returns an object with the field
 
 Prepares the terminal for a payment. Checks whether the CardReader is ready to tramsmit
 and if an instance of the CardReaderManager is available.
+
+#### setup
+
+`SumUp.setup()`
+
+Will setup/initiate the SumUP SDK. Usely after App launch.
+For iOS, this is **required** before using other functions.
+
+#### test
+
+`SumUp.test()`
+
+Test the SumUp SDK integration.
+Currently only for iOS.
 
 #### closeConnection
 

--- a/README.md
+++ b/README.md
@@ -338,8 +338,9 @@ Here are all additional codes:
 | 114  | Authenticate was successful            |
 | 115  | Can't parse amount                     |
 | 116  | Can't parse currency                   |
-| 117  | Payment error                          |
-| 118  | No affiliate key available             |
+| 117  | Can't parse title                      |
+| 118  | Payment error                          |
+| 119  | No affiliate key available             |
 
 ## Common problems
 

--- a/examples/ionic/src/app/home/home.page.ts
+++ b/examples/ionic/src/app/home/home.page.ts
@@ -56,7 +56,7 @@ export class HomePage {
 
   private async pay(): Promise<void> {
     try {
-      this.sumupResult = await this.sumUp.pay(10.01, 'EUR');
+      this.sumupResult = await this.sumUp.pay(10.01, 'Title', 'EUR');
     } catch (e) {
       this.sumupResult = e;
     }

--- a/examples/javascript/www/js/index.js
+++ b/examples/javascript/www/js/index.js
@@ -159,6 +159,7 @@ var app = {
   pay() {
     SumUp.pay(
       10.0,
+      "Title",
       "EUR",
       function(success) {
         console.log(success);

--- a/plugin.xml
+++ b/plugin.xml
@@ -66,6 +66,6 @@
         <source-file src="src/ios/SumUp.swift" />
         <preference name="SUMUP_API_KEY" />
         <dependency id="cordova-plugin-add-swift-support" version="2.0.2"/>
-        <framework src="SumUpSDK" type="podspec" spec="~> 3.2.0" />
+        <framework src="SumUpSDK" type="podspec" spec="~> 4.1.1" />
     </platform>
 </plugin>

--- a/src/android/SumUp.java
+++ b/src/android/SumUp.java
@@ -268,6 +268,18 @@ public class SumUp extends CordovaPlugin {
         return true;
     }
 
+    // setup the SDK. Only available for iOS right now.. (TODO?)
+    private boolean setup(JSONArray args, CallbackContext callbackContext) {
+        callback = callbackContext;
+        return true;
+    }
+
+    // test the SDK integration. Only available for iOS right now.. (TODO?)
+    private boolean test(JSONArray args, CallbackContext callbackContext) {
+        callback = callbackContext;
+        return true;
+    }
+
     // closes the connection to the card reader
     private boolean closeConnection(JSONArray args, CallbackContext callbackContext) {
         callback = callbackContext;

--- a/src/android/SumUp.java
+++ b/src/android/SumUp.java
@@ -47,6 +47,8 @@ public class SumUp extends CordovaPlugin {
     private static final int REQUEST_CODE_LOGIN = 1;
     private static final int REQUEST_CODE_PAYMENT = 2;
     private static final int REQUEST_CODE_PAYMENT_SETTINGS = 3;
+    private static final int REQUEST_CODE_SETUP = 4;
+    private static final int REQUEST_CODE_TEST = 5;
 
     // Response codes
     private static final int LOGIN_ERROR = 100;
@@ -271,12 +273,20 @@ public class SumUp extends CordovaPlugin {
     // setup the SDK. Only available for iOS right now.. (TODO?)
     private boolean setup(JSONArray args, CallbackContext callbackContext) {
         callback = callbackContext;
+
+        JSONObject obj = createReturnObject(REQUEST_CODE_SETUP, "Not required for Android");
+        returnCordovaPluginResult(PluginResult.Status.OK, obj, false);
+        
         return true;
     }
 
     // test the SDK integration. Only available for iOS right now.. (TODO?)
     private boolean test(JSONArray args, CallbackContext callbackContext) {
         callback = callbackContext;
+
+        JSONObject obj = createReturnObject(REQUEST_CODE_TEST, "Currently not available for Android");
+        returnCordovaPluginResult(PluginResult.Status.OK, obj, false);
+
         return true;
     }
 

--- a/src/android/SumUp.java
+++ b/src/android/SumUp.java
@@ -344,7 +344,7 @@ public class SumUp extends CordovaPlugin {
                 .total(amount)
                 .currency(currency)
                 .title(title)
-                .skipSuccessScreen()
+                //.skipSuccessScreen()
                 .build();
 
         Runnable runnable = () -> {

--- a/src/android/SumUp.java
+++ b/src/android/SumUp.java
@@ -322,9 +322,18 @@ public class SumUp extends CordovaPlugin {
             return false;
         }
 
+        String title;
+        try {
+            title = new String(args.get(1).toString());
+        } catch (Exception e) {
+            JSONObject obj = createReturnObject(CANT_PARSE_CURRENCY, "Can't parse title");
+            returnCordovaPluginResult(PluginResult.Status.ERROR, obj, true);
+            return false;
+        }
+
         SumUpPayment.Currency currency;
         try {
-            currency = SumUpPayment.Currency.valueOf(args.get(1).toString());
+            currency = SumUpPayment.Currency.valueOf(args.get(2).toString());
         } catch (Exception e) {
             JSONObject obj = createReturnObject(CANT_PARSE_CURRENCY, "Can't parse currency");
             returnCordovaPluginResult(PluginResult.Status.ERROR, obj, true);
@@ -334,6 +343,7 @@ public class SumUp extends CordovaPlugin {
         SumUpPayment payment = SumUpPayment.builder()
                 .total(amount)
                 .currency(currency)
+                .title(title)
                 .skipSuccessScreen()
                 .build();
 

--- a/src/android/SumUp.java
+++ b/src/android/SumUp.java
@@ -68,8 +68,9 @@ public class SumUp extends CordovaPlugin {
     private static final int AUTH_SUCCESSFUL = 114;
     private static final int CANT_PARSE_AMOUNT = 115;
     private static final int CANT_PARSE_CURRENCY = 116;
-    private static final int PAYMENT_ERROR = 117;
-    private static final int NO_AFFILIATE_KEY = 118;
+    private static final int CANT_PARSE_TITLE = 117;
+    private static final int PAYMENT_ERROR = 118;
+    private static final int NO_AFFILIATE_KEY = 119;
 
     private CallbackContext callback = null;
 
@@ -336,7 +337,7 @@ public class SumUp extends CordovaPlugin {
         try {
             title = new String(args.get(1).toString());
         } catch (Exception e) {
-            JSONObject obj = createReturnObject(CANT_PARSE_CURRENCY, "Can't parse title");
+            JSONObject obj = createReturnObject(CANT_PARSE_TITLE, "Can't parse title");
             returnCordovaPluginResult(PluginResult.Status.ERROR, obj, true);
             return false;
         }

--- a/src/android/SumUp.java
+++ b/src/android/SumUp.java
@@ -337,18 +337,21 @@ public class SumUp extends CordovaPlugin {
         try {
             title = new String(args.get(1).toString());
         } catch (Exception e) {
-            JSONObject obj = createReturnObject(CANT_PARSE_TITLE, "Can't parse title");
-            returnCordovaPluginResult(PluginResult.Status.ERROR, obj, true);
-            return false;
+            title = "";
         }
 
         SumUpPayment.Currency currency;
         try {
             currency = SumUpPayment.Currency.valueOf(args.get(2).toString());
         } catch (Exception e) {
-            JSONObject obj = createReturnObject(CANT_PARSE_CURRENCY, "Can't parse currency");
-            returnCordovaPluginResult(PluginResult.Status.ERROR, obj, true);
-            return false;
+            if (!SumUpAPI.isLoggedIn()) {
+                // no merchant account currently logged in
+                JSONObject obj = createReturnObject(CANT_PARSE_CURRENCY, "Can't parse currency");
+                returnCordovaPluginResult(PluginResult.Status.ERROR, obj, true);
+                return false;
+            } else {
+                currency = SumUpAPI.getCurrentMerchant().getCurrency();
+            }
         }
 
         SumUpPayment payment = SumUpPayment.builder()

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -58,5 +58,5 @@ android {
 
 dependencies {
     implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.sumup:merchant-sdk:3.4.0'
+    implementation 'com.sumup:merchant-sdk:3.2.2'
 }

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -58,5 +58,5 @@ android {
 
 dependencies {
     implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.sumup:merchant-sdk:3.2.1'
+    implementation 'com.sumup:merchant-sdk:3.4.0'
 }

--- a/src/ios/SumUp.swift
+++ b/src/ios/SumUp.swift
@@ -127,6 +127,14 @@ import SumUpSDK;
         returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);
     }
 
+    @objc(setup:)
+    func setup(command: CDVInvokedUrlCommand) {
+        let affiliate_key = getAffiliateKey(); print(affiliate_key);
+        SumUpSDK.setup(withAPIKey: affiliate_key);
+        let obj = createReturnObject(code: SUCCESS, message: "SumUp setup executed. See console.");
+        returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);
+    }
+    
     @objc(closeConnection:)
     func closeConnection(command: CDVInvokedUrlCommand) {
         let obj = createReturnObject(code: 104, message: "Close connection is not available on iOS");

--- a/src/ios/SumUp.swift
+++ b/src/ios/SumUp.swift
@@ -122,6 +122,8 @@ import SumUpSDK;
 
     @objc(prepare:)
     func prepare(command: CDVInvokedUrlCommand) {
+        let affiliate_key = getAffiliateKey(); print(affiliate_key);
+        SumUpSDK.setup(withAPIKey: affiliate_key);
         SumUpSDK.prepareForCheckout();
         let obj = createReturnObject(code: SUCCESS, message: "SumUp checkout prepared successfully");
         returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);

--- a/src/ios/SumUp.swift
+++ b/src/ios/SumUp.swift
@@ -135,6 +135,13 @@ import SumUpSDK;
         returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);
     }
     
+    @objc(test:)
+    func test(command: CDVInvokedUrlCommand) {
+        SumUpSDK.testIntegration();
+        let obj = createReturnObject(code: SUCCESS, message: "SumUp test integration executed. See console.");
+        returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);
+    }
+
     @objc(closeConnection:)
     func closeConnection(command: CDVInvokedUrlCommand) {
         let obj = createReturnObject(code: 104, message: "Close connection is not available on iOS");

--- a/src/ios/SumUp.swift
+++ b/src/ios/SumUp.swift
@@ -197,7 +197,7 @@ import SumUpSDK;
                 }
 
                 if safeResult.success {
-                    let obj = self.createReturnObject(code: 118, message: "Payment success!");
+                    let obj = self.createPaymentReturnObject(result: safeResult);
                     self.returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);
                     return
                 } else {
@@ -212,6 +212,24 @@ import SumUpSDK;
     // returns the affiliate key, which is provided in package.json
     private func getAffiliateKey() -> String {
         return (Bundle.main.infoDictionary?["SUMUP_API_KEY"] as? String)!;
+    }
+
+    private func createPaymentReturnObject(result: CheckoutResult) -> [AnyHashable : Any] {
+        let paymentResult: [AnyHashable : Any] = [
+            "transaction_code" : result.transactionCode,
+            "merchant_code": result.additionalInfo?["merchant_code"],
+            "amount": result.additionalInfo?["amount"],
+            "tip_amount": result.additionalInfo?["tip_amount"],
+            "vat_amount": result.additionalInfo?["vat_amount"],
+            "currency": result.additionalInfo?["currency"],
+            "status": result.additionalInfo?["status"],
+            "payment_type": result.additionalInfo?["payment_type"],
+            "entry_mode": result.additionalInfo?["entry_mode"],
+            "installments": result.additionalInfo?["installments"],
+            "card_type": result.additionalInfo?["card_type"],
+            "last_4_digits": result.additionalInfo?["last_4_digits"],
+        ];
+        return paymentResult;
     }
 
     private func createReturnObject(code: Int, message: String) -> [AnyHashable : Any] {

--- a/src/ios/SumUp.swift
+++ b/src/ios/SumUp.swift
@@ -122,8 +122,6 @@ import SumUpSDK;
 
     @objc(prepare:)
     func prepare(command: CDVInvokedUrlCommand) {
-        let affiliate_key = getAffiliateKey(); print(affiliate_key);
-        SumUpSDK.setup(withAPIKey: affiliate_key);
         SumUpSDK.prepareForCheckout();
         let obj = createReturnObject(code: SUCCESS, message: "SumUp checkout prepared successfully");
         returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);

--- a/src/ios/SumUp.swift
+++ b/src/ios/SumUp.swift
@@ -20,8 +20,9 @@ import SumUpSDK;
     private let AUTH_SUCCESSFUL: Int = 114;
     private let CANT_PARSE_AMOUNT: Int = 115;
     private let CANT_PARSE_CURRENCY: Int = 116;
-    private let PAYMENT_ERROR: Int = 117;
-    private let PAYMENT_SUCCESS: Int = 118;
+    private let CANT_PARSE_TITLE: Int = 117;
+    private let PAYMENT_ERROR: Int = 118;
+    private let NO_AFFILIATE_KEY: Int = 119;
 
     @objc(login:)
     func login(command: CDVInvokedUrlCommand) {
@@ -75,7 +76,7 @@ import SumUpSDK;
 
     @objc(auth:)
     func auth(command: CDVInvokedUrlCommand) {
-        let obj = createReturnObject(code: 112, message: "Authenticate is not available on iOS");
+        let obj = createReturnObject(code: AUTH_ERROR, message: "Authenticate is not available on iOS");
         returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);
     }
 
@@ -143,7 +144,7 @@ import SumUpSDK;
 
     @objc(closeConnection:)
     func closeConnection(command: CDVInvokedUrlCommand) {
-        let obj = createReturnObject(code: 104, message: "Close connection is not available on iOS");
+        let obj = createReturnObject(code: FAILED_CLOSE_CARD_READER_CONN, message: "Close connection is not available on iOS");
         returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);
     }
 
@@ -168,7 +169,7 @@ import SumUpSDK;
             }
 
             guard var currency = SumUpSDK.currentMerchant?.currencyCode else {
-                let obj = createReturnObject(code: 102, message: "Not logged in");
+                let obj = createReturnObject(code: AUTH_ERROR, message: "Not logged in");
                 returnCordovaPluginResult(status: CDVCommandStatus_ERROR, obj: obj, command: command);
                 return
             }
@@ -182,17 +183,17 @@ import SumUpSDK;
             SumUpSDK.checkout(with: request, from: self.viewController) { (result: CheckoutResult?, error: Error?) in
                 if let safeError = error as NSError? {
                     if (safeError.domain == SumUpSDKErrorDomain) && (safeError.code == SumUpSDKError.accountNotLoggedIn.rawValue) {
-                        let obj = self.createReturnObject(code: 102, message: "Not logged in!");
+                        let obj = self.createReturnObject(code: self.AUTH_ERROR, message: "Not logged in!");
                         self.returnCordovaPluginResult(status: CDVCommandStatus_ERROR, obj: obj, command: command);
                     } else {
-                        let obj = self.createReturnObject(code: 117, message: "General error");
+                        let obj = self.createReturnObject(code: self.PAYMENT_ERROR, message: "General error");
                         self.returnCordovaPluginResult(status: CDVCommandStatus_ERROR, obj: obj, command: command);
                     }
                     return
                 }
 
                 guard let safeResult = result else {
-                    let obj = self.createReturnObject(code: 117, message: "No error, no result should happen");
+                    let obj = self.createReturnObject(code: self.PAYMENT_ERROR, message: "No error, no result should happen");
                     self.returnCordovaPluginResult(status: CDVCommandStatus_ERROR, obj: obj, command: command);
                     return
                 }
@@ -202,7 +203,7 @@ import SumUpSDK;
                     self.returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);
                     return
                 } else {
-                    let obj = self.createReturnObject(code: 117, message: "Payment cancelled! No error, no success. No charge.");
+                    let obj = self.createReturnObject(code: self.PAYMENT_ERROR, message: "Payment cancelled! No error, no success. No charge.");
                     self.returnCordovaPluginResult(status: CDVCommandStatus_ERROR, obj: obj, command: command);
                     return
                 }

--- a/src/ios/SumUp.swift
+++ b/src/ios/SumUp.swift
@@ -154,9 +154,15 @@ import SumUpSDK;
     func pay(command: CDVInvokedUrlCommand) {
         var amount: NSDecimalNumber;
         var number: NSNumber;
+        var title: String;
+        var curr: String;
         
         if((command.arguments != nil) && command.arguments.count > 0) {
             number = command.arguments[0] as! NSNumber;
+            title = command.arguments[1] as! String;
+            curr = command.arguments[2] as! String;
+
+            // Convert amount to NSDecimalNumber safely
             amount = NSDecimalNumber(decimal: number.decimalValue);
 
             guard amount != NSDecimalNumber.zero else {
@@ -164,11 +170,12 @@ import SumUpSDK;
             }
             
             guard let currency = SumUpSDK.currentMerchant?.currencyCode else {
-                print("Not logged in");
+                let obj = createReturnObject(code: 117, message: "Not logged in");
+                returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);
                 return
             }
             
-            let request = CheckoutRequest(total: amount, title: "test", currencyCode: currency);
+            let request = CheckoutRequest(total: amount, title: title, currencyCode: currency);
             
             SumUpSDK.checkout(with: request, from: self.viewController) { (result: CheckoutResult?, error: Error?) in
                 if let safeError = error as NSError? {

--- a/src/ios/SumUp.swift
+++ b/src/ios/SumUp.swift
@@ -150,6 +150,7 @@ import SumUpSDK;
     @objc(pay:)
     func pay(command: CDVInvokedUrlCommand) {
         var amount: NSDecimalNumber;
+        var currency: String;
         var number: NSNumber;
         var title: String;
         var curr: String;
@@ -166,14 +167,14 @@ import SumUpSDK;
                 return
             }
 
+            guard var currency = SumUpSDK.currentMerchant?.currencyCode else {
+                let obj = createReturnObject(code: 102, message: "Not logged in");
+                returnCordovaPluginResult(status: CDVCommandStatus_ERROR, obj: obj, command: command);
+                return
+            }
+
             if (curr != ""){
-                let currency = curr;
-            } else {
-                guard let currency = SumUpSDK.currentMerchant?.currencyCode else {
-                    let obj = createReturnObject(code: 102, message: "Not logged in");
-                    returnCordovaPluginResult(status: CDVCommandStatus_ERROR, obj: obj, command: command);
-                    return
-                }
+                currency = curr;
             }
             
             let request = CheckoutRequest(total: amount, title: title, currencyCode: currency);

--- a/src/ios/SumUp.swift
+++ b/src/ios/SumUp.swift
@@ -154,12 +154,9 @@ import SumUpSDK;
         var currency: String;
         var number: NSNumber;
         var title: String;
-        var curr: String;
         
         if((command.arguments != nil) && command.arguments.count > 0) {
             number = command.arguments[0] as! NSNumber;
-            title = command.arguments[1] as! String;
-            curr = command.arguments[2] as! String;
 
             // Convert amount to NSDecimalNumber safely
             amount = NSDecimalNumber(decimal: number.decimalValue);
@@ -168,14 +165,22 @@ import SumUpSDK;
                 return
             }
 
-            guard var currency = SumUpSDK.currentMerchant?.currencyCode else {
-                let obj = createReturnObject(code: AUTH_ERROR, message: "Not logged in");
-                returnCordovaPluginResult(status: CDVCommandStatus_ERROR, obj: obj, command: command);
-                return
+            if (command.arguments[1] as? String != nil){
+                title = command.arguments[1] as! String;
+            } else {
+                title = "";
             }
-
-            if (curr != ""){
-                currency = curr;
+            
+            if (command.arguments[2] as? String != nil){
+                currency = command.arguments[2] as! String;
+            } else {
+                if (SumUpSDK.currentMerchant?.currencyCode != nil) {
+                    currency = SumUpSDK.currentMerchant?.currencyCode as! String;
+                } else {
+                    let obj = createReturnObject(code: AUTH_ERROR, message: "Not logged in");
+                    returnCordovaPluginResult(status: CDVCommandStatus_ERROR, obj: obj, command: command);
+                    return
+                }
             }
             
             let request = CheckoutRequest(total: amount, title: title, currencyCode: currency);

--- a/src/ios/SumUp.swift
+++ b/src/ios/SumUp.swift
@@ -26,20 +26,34 @@ import SumUpSDK;
     func login(command: CDVInvokedUrlCommand) {
         let affiliate_key = getAffiliateKey(); print(affiliate_key);
 
-        // Access token provided
         if((command.arguments != nil) && command.arguments.count > 0) {
-            var accessToken = command.arguments[0]; print(accessToken);
+            let accessToken = command.arguments[0]; print(accessToken);
 
-            SumUpSDK.login(withToken: accessToken as! String){ (success: Bool, error: Error?) in
-                if(success) {
-                    let obj = self.createReturnObject(code: self.SUCCESS, message: "User sucessfully logged in");
-                    self.returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);
+            if (accessToken as! String != "") {
+                SumUpSDK.login(withToken: accessToken as! String){ (success: Bool, error: Error?) in
+                    if(success) {
+                        let obj = self.createReturnObject(code: self.SUCCESS, message: "User sucessfully logged in");
+                        self.returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);
+                    }
+
+                    guard error == nil else {
+                        let obj = self.createReturnObject(code: self.LOGIN_ERROR, message: error!.localizedDescription);
+                        self.returnCordovaPluginResult(status: CDVCommandStatus_ERROR, obj: obj, command: command);
+                        return
+                    }
                 }
+            } else {
+                SumUpSDK.presentLogin(from: self.viewController, animated: true) { (success: Bool, error: Error?) in
+                    if(success) {
+                        let obj = self.createReturnObject(code: self.SUCCESS, message: "User sucessfully logged in");
+                        self.returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);
+                    }
 
-                guard error == nil else {
-                    let obj = self.createReturnObject(code: self.LOGIN_ERROR, message: error!.localizedDescription);
-                    self.returnCordovaPluginResult(status: CDVCommandStatus_ERROR, obj: obj, command: command);
-                    return
+                    guard error == nil else {
+                        let obj = self.createReturnObject(code: self.LOGIN_ERROR, message: error!.localizedDescription);
+                        self.returnCordovaPluginResult(status: CDVCommandStatus_OK, obj: obj, command: command);
+                        return
+                    }
                 }
             }
         } else {

--- a/typings/sumup.d.ts
+++ b/typings/sumup.d.ts
@@ -102,7 +102,8 @@ declare module "cordova-sumup-plugin" {
    *
    * @export
    * @param {number} amount
-   * @param {string} currencycode
+   * @param {string} title (optional)
+   * @param {string} currencycode (optional)
    */
-  export function pay(amount: number, currencycode: string): void;
+  export function pay(amount: number, title?:string, currencycode?: string): void;
 }

--- a/typings/sumup.d.ts
+++ b/typings/sumup.d.ts
@@ -76,6 +76,21 @@ declare module "cordova-sumup-plugin" {
   export function prepare(): void;
 
   /**
+   * Will setup the SumUP SDK.
+   * This action is required before using other functions.
+   *
+   * @export
+   */
+  export function setup(): void;
+
+  /**
+   * Test the SumUp integration using SDK tests.
+   *
+   * @export
+   */
+  export function test(): void;
+
+  /**
    * Closes the connection to the payment terminale
    *
    * @export

--- a/typings/sumup.d.ts
+++ b/typings/sumup.d.ts
@@ -105,5 +105,5 @@ declare module "cordova-sumup-plugin" {
    * @param {string} title (optional)
    * @param {string} currencycode (optional)
    */
-  export function pay(amount: number, title?:string, currencycode?: string): void;
+  export function pay(amount: number, title?: string, currencycode?: string): void;
 }

--- a/www/sumup.js
+++ b/www/sumup.js
@@ -31,10 +31,16 @@ module.exports = {
   prepare: (success, failure) => {
     cordova.exec(success, failure, CLASS, "prepare", []);
   },
+  setup: (success, failure) => {
+    cordova.exec(success, failure, CLASS, "setup", []);
+  },
+  test: (success, failure) => {
+    cordova.exec(success, failure, CLASS, "test", []);
+  },
   closeConnection: (success, failure) => {
     cordova.exec(success, failure, CLASS, "closeConnection", []);
   },
-  pay: (amount, currencycode, success, failure) => {
-    cordova.exec(success, failure, CLASS, "pay", [amount, currencycode]);
+  pay: (amount, title, currencycode, success, failure) => {
+    cordova.exec(success, failure, CLASS, "pay", [amount, title, currencycode]);
   }
 };


### PR DESCRIPTION
#34 #12 #2 

Support for iOS
- [UPDATED] SumUP iOS SDK to version 4.1.1
- [UPDATED] SumUP Android SDK to version 3.2.2

For iOS it is important to first run the prepare function so that the native SumUP SDK is being initiated as needed.
After that, run the login function and prepare function again to initiate a payment using the pay function.